### PR TITLE
fix: Load Fira Mono font in Hopscotch theme over HTTPS

### DIFF
--- a/Prism.js/hopscotch.css
+++ b/Prism.js/hopscotch.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Fira+Mono);
+@import url(https://fonts.googleapis.com/css?family=Fira+Mono);
 /*
  * Hopscotch
  * by Jan T. Sott

--- a/highlight.js/hopscotch.css
+++ b/highlight.js/hopscotch.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Fira+Mono);
+@import url(https://fonts.googleapis.com/css?family=Fira+Mono);
 
 /*
  * Hopscotch v1.0.1


### PR DESCRIPTION
Fixes #9 